### PR TITLE
Add Dockerfile and instructions for manual build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.12
+
+RUN apt update && \
+    apt -y install build-essential npm && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN addgroup --gid 1000 node \
+    && useradd --create-home --uid 1000 --gid node --shell /bin/sh node
+
+USER node
+
+CMD /bin/sh

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This plugin will add UI for users to start new Jitsi meetings in a Mattermost ch
 
 Go to the [releases page of this Github repository](https://github.com/seansackowitz/mattermost-plugin-jitsi/releases) and download the latest release for your server architecture. You can upload this file in the Mattermost system console to install the plugin.
 
+### Manual build
+
+You can use docker to compile the binaries yourself. Just run the provided `./docker-make` shell script which will build a docker image with necesarry build dependencies and runs `make all` afterwards.  
+You can also use make targets like `dist` (`./docker-make dist`) from the [Makefile](./Makefile).
+
 ## Developing
 
 This plugin contains both a server and web app portion.

--- a/docker-make
+++ b/docker-make
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+sudo docker build -t mattermost-plugin-jitsi-builder .
+sudo docker run --rm -it -v $(pwd):/src -w /src mattermost-plugin-jitsi-builder make "$@"


### PR DESCRIPTION
This PR adds a dockerfile and instructions for manual build of the plugin.  
Not everyone wants to use pre-build binaries, so let's make it easier for them to build the plugin by themselves. :slightly_smiling_face: 